### PR TITLE
skip comment lines in the gemfile

### DIFF
--- a/lib/gem_dating/input.rb
+++ b/lib/gem_dating/input.rb
@@ -24,6 +24,7 @@ module GemDating
 
     def gem_line(line)
       return if line.strip == "end"
+      return if line =~ /^\s*#/
 
       if line.start_with? "gem("
         line.split("(")[1].split(",")[0]

--- a/test/input_test.rb
+++ b/test/input_test.rb
@@ -51,4 +51,15 @@ class TestInput < Minitest::Test
     gems = GemDating::Input.new(pasteboard).gems
     assert_equal ["rails", "sqlite3"], gems
   end
+
+  def test_hash_alone_causes_confusion
+    pasteboard = <<-TEXT
+      # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
+      gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+      #
+      gem "bcrypt", "~> 3.1"
+    TEXT
+    gems = GemDating::Input.new(pasteboard).gems
+    assert_equal ["tzinfo-data", "bcrypt"], gems
+  end
 end


### PR DESCRIPTION
A standalone comment line causes the following to show up in the output:

```
#                              | 0.0.0.UNKNOWN | 1970-01-01
```

Turns out this is a parsing issue, and all comment lines should just be skipped.
