### PR TITLE
Nitpick: adjust install instructions to prevent autoloading

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ cause trouble if you're targeting an upgrade to Ruby 4.1
 `gem install gem_dating` or add it to your Gemfile:
 
 ```ruby
-gem 'gem_dating', group: [:development]
+gem 'gem_dating', group: [:development], require: false
 ```
 
 ### Running GemDating


### PR DESCRIPTION
Looking at the code, the gem doesn't interact with the app the Gemfile belongs to in any way, so there's no point in autoloading it (like Rails would for instance).