### PR TITLE
Fix simpler conditional cases

### DIFF
--- a/lib/gem_dating/input.rb
+++ b/lib/gem_dating/input.rb
@@ -19,18 +19,18 @@ module GemDating
       lines.each_with_object([]) do |line, gems|
         line = gem_line(line.strip)
         gems << cleanup(line) if line
-      end
+      end.uniq
     end
 
     def gem_line(line)
-      return if line.strip == "end"
-      return if line =~ /^\s*#/
+      single_word_ruby_statements = %w{end else #}
+      return if single_word_ruby_statements.include? line.strip
 
       if line.start_with? "gem("
         line.split("(")[1].split(",")[0]
       elsif line.start_with? "gem"
         line.split[1].split(",")[0]
-      elsif line.split.length == 1
+      elsif line.split.length == 1 # match "just" gemname
         line
       end
     end

--- a/test/input_test.rb
+++ b/test/input_test.rb
@@ -62,4 +62,18 @@ class TestInput < Minitest::Test
     gems = GemDating::Input.new(pasteboard).gems
     assert_equal ["tzinfo-data", "bcrypt"], gems
   end
+
+  def test_conditional_versioning
+    pasteboard = <<-TEXT
+      if rails_edge?
+        gem 'rails'
+      elsif rails_next?
+        gem 'rails', '~> 6.2'
+      else
+        gem 'rails', '~> 5.2.8.1'
+      end
+    TEXT
+    gems = GemDating::Input.new(pasteboard).gems
+    assert_equal ["rails"], gems
+  end
 end


### PR DESCRIPTION
This feels kind of gross and a "where will it end" kind of situation.

For example, we could filter out `begin`, `rescue`, etc and it still wouldn't be enough for something like this:

```
      begin
        v = find_version_from_server
      rescue
        puts "something bad happened"
      ensure
        v = "1.0"
      end

      gem 'super-secret-internal', v

      def find_version_from_server
        class Finder < Other
          def initialize
            super
          end
        end
        Finder.go!
      end
```

I'm kind of ok with return UNKNOWN for `Finder.go!`, but I could imagine a version of this that defines a `gem` method and eval's it.  But that would put a crimp on any future plans of hosting this tool since we'd be doing RCE all over the place.

We could also split "Gemfile" evaluation from "no Gemfile" evaluation, they're lumped together because it was easy, but maybe not prudent.