### PR TITLE
Add --help options to cli

### DIFF
--- a/lib/gem_dating/cli.rb
+++ b/lib/gem_dating/cli.rb
@@ -3,19 +3,30 @@ module GemDating
     SUCCESS = 0
     GENERAL_ERROR = 1
 
+    HELP_TEXT =
+      <<~HELP
+        Usage: gem_dating [--help | -h] [<GEMFILE_FILEPATH>]
+      HELP
+
     def initialize(argv)
-      @argv = argv
+      args, file_path = argv.partition { |arg| (arg =~ /--\w+/) || (arg =~ /(-[a-z])/) }
+
+      @args = args
+      @file_path = file_path.first
     end
 
     def run
-      if @argv.empty?
-        $stdout << "Usage: gem_dating [GEMFILE_FILEPATH]\n"
+      if (@args & ['-h', '--help']).any?
+        $stdout << HELP_TEXT
+        return SUCCESS
+      end
+
+      unless @file_path
+        $stdout << HELP_TEXT
         return GENERAL_ERROR
       end
 
-      path = @argv.first
-
-      $stdout << GemDating.from_file(path).table_print << "\n"
+      $stdout << GemDating.from_file(@file_path).table_print << "\n"
 
       SUCCESS
     end

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -49,10 +49,7 @@ class GemDating::CliTest < Minitest::Test
       exit_code = GemDating::Cli.new([]).run
     end
 
-    expected_out =
-      <<~EXPECTED
-        Usage: gem_dating [GEMFILE_FILEPATH]
-    EXPECTED
+    expected_out = GemDating::Cli::HELP_TEXT
 
     assert_equal 1, exit_code
     assert_equal expected_out, stdout
@@ -62,5 +59,21 @@ class GemDating::CliTest < Minitest::Test
     assert_raises Errno::ENOENT do
       GemDating::Cli.new(["test/Gemfile.nope"]).run
     end
+  end
+
+  def test_help_option
+    exit_codes = []
+
+    stdout, _stderr = capture_io do
+      ["--help", "-h"].each do |help_option|
+        exit_codes << GemDating::Cli.new([help_option]).run
+      end
+    end
+
+    expected_out = GemDating::Cli::HELP_TEXT
+
+    assert_equal [0], exit_codes.uniq
+    assert_includes expected_out, stdout.split("\n").first
+    assert_includes expected_out, stdout.split("\n").last
   end
 end


### PR DESCRIPTION
Closes #12, thank you for the suggestion @brandondrew !

I've opted to defer adding "proper" arg parsing, and introducing seams for the cli to evokes their behaviour. 
Will defer that to a time where we add features that change the underlying gem behaviour.

Also noting that `-?` as a help option is a strong Windows convention, but is a struggle to implement with how zsh handles file matching with the `?` metacharacter. I think the two other choices should cover our needs, and match expectations other gems set.