### PR TITLE
Don't break when finding `gemspec` in the Gemfile

### DIFF
--- a/lib/gem_dating/input.rb
+++ b/lib/gem_dating/input.rb
@@ -23,7 +23,7 @@ module GemDating
     end
 
     def gem_line(line)
-      single_word_ruby_statements = %w{end else #}
+      single_word_ruby_statements = %w{end else # gemspec}
       return if single_word_ruby_statements.include? line.strip
 
       if line.start_with? "gem("

--- a/test/input_test.rb
+++ b/test/input_test.rb
@@ -76,4 +76,18 @@ class TestInput < Minitest::Test
     gems = GemDating::Input.new(pasteboard).gems
     assert_equal ["rails"], gems
   end
+
+  def test_gemspec_in_gemfile
+    pasteboard = <<-TEXT
+      source "https://rubygems.org"
+      # Specify your gem's dependencies in gem_dating.gemspec
+      
+      gemspec
+
+      gem "rake"
+    TEXT
+
+    gems = GemDating::Input.new(pasteboard).gems
+    assert_equal ["rake"], gems
+  end
 end


### PR DESCRIPTION
I was using the Gemfile in the project to test against for improving the CLI and discovered that we were blowing up on a Gemfile that invokes `gemspec`.

Small fix, but now `gem_dating` works on it's own Gemfile 😅 